### PR TITLE
Change default behaviour to make sure the function isnt quietly verified

### DIFF
--- a/ssh_server.erl
+++ b/ssh_server.erl
@@ -8,8 +8,8 @@ start() ->
         {system_dir, "/root/ssh_keys"},
         {auth_methods, "password"},
         {pwdfun, fun(User, Pass) ->
-            io:format("Login attempt ~p/~p~n", [User, Pass]),
-            true
+            io:format("Login attempt ~p/~p~n", [User, Pass]), % I'm unsure where this output will be sent, since it is sent to the output device of a spawned function
+            false % we should default to false
         end}
     ]) of
         {ok, Pid} ->


### PR DESCRIPTION
The pwdfun was made to return true on all inputs, and the log info is dropped on the python side (I think)